### PR TITLE
Revert "Dependabot auto merge"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "semver:minor"
-      - match:
-          dependency_type: "production"
-          update_type: "semver:patch"


### PR DESCRIPTION
Reverts yuya-takeyama/replicate-docker-version-tag-action#7

It doesn't work with `version: 2`:
https://github.com/yuya-takeyama/replicate-docker-version-tag-action/runs/1140834784